### PR TITLE
[tentController] Performance-friendly tentSimulate()

### DIFF
--- a/Data Files/MWSE/mods/mer/ashfall/camping/tents/tentController.lua
+++ b/Data Files/MWSE/mods/mer/ashfall/camping/tents/tentController.lua
@@ -333,22 +333,30 @@ end)
 
 
 local function cullRain(position)
-    local rain = tes3.worldController.weatherController.sceneRainRoot
-    for raindrop in table.traverse{rain} do
-        if not raindrop.appCulled then
-            if position:distance(raindrop.worldTransform.translation) < 400 then
-                raindrop.appCulled = true
+    local particlesActive = tes3.worldController.weatherController.particlesActive
+    for _, particle in pairs(particlesActive) do
+        if not particle.object.appCulled then
+            if position:distance(particle.object.worldTransform.translation) < 400 then
+                particle.object.appCulled = true
             end
         end
     end
 end
 
+local function isBadWeather(weatherIndex)
+    return (weatherIndex == tes3.weather.rain) or (weatherIndex == tes3.weather.thunder)
+end
+
 --Must be done each frame to remove the particles as they get added
 local function tentSimulate(e)
     if config.disableRainInTents then
-        if currentTent and currentTent:valid() then
-            local position = currentTent.position:copy()
-            cullRain(position)
+        if currentTent and currentTent:valid() and common.data.insideTent then
+            if isBadWeather(tes3.worldController.weatherController.currentWeather.index)
+                or (tes3.worldController.weatherController.nextWeather 
+                    and isBadWeather(tes3.worldController.weatherController.nextWeather.index)) then
+                local position = currentTent.position:copy()
+                cullRain(position)
+            end
         end
     end
 end


### PR DESCRIPTION
Hey mer, awesome mod 👍   just an itsy-bitsy issue I'm experiencing with it on my modest machine.

In its current state, `tentSimulate()` in tentController.lua will begin to `cullRain()` even if it's not currently raining. Rain culling also occurs independently of whether you are inside or outside the tent. Traversing over the entire `sceneRainRoot` can be a little too hardware-intensive when there's 3000 niNodes to traverse over on every frame (that's the `Max Raindrops` value for [Weather Thunderstorm] in my morrowind.ini)

The main reason behind this PR is to make `tentSimulate()` have less of an impact on FPS when having an ashfall modular tent up and active.

Proposed changes:

1. Add extra checks before calling `cullRain()`:
 - `common.data.insideTent` (rain culling only makes sense when inside the tent imo, thus no impact on framerate when not sheltered inside the tent)
 - check if it's currently raining or about to rain (need this for what comes next, because we're only going to cull rain particles)

2. Switch from traversing over `tes3.worldController.weatherController.sceneRainRoot` to iterating over `tes3.worldController.weatherController.particlesActive` (Same result, but with less computation. At least, this is what I'm seeing at first glance. Huge FPS gain on my end.)

Apologies if mistaken, I'm sort of a novice at modding and lua.