### PR TITLE
Better underwater check for frostBreath

### DIFF
--- a/Data Files/MWSE/mods/mer/ashfall/effects/frostBreath.lua
+++ b/Data Files/MWSE/mods/mer/ashfall/effects/frostBreath.lua
@@ -51,7 +51,7 @@ function this.doFrostBreath()
                 return
             end
             local isAlive = ( ref.mobile.health.current > 0 )
-            local isAboveWater = ( ref.mobile.underwater == false )
+            local isAboveWater = ( ref.mobile.isSwimming == false )
             if isCold and isAboveWater and isAlive and checkEnabled() then
                 if isGuar then
                     addBreath(node, 25, 0, 0, 2.0)


### PR DESCRIPTION
`mobile.underwater` doesn't trigger when the mobile is under effect of `waterbreathing`. `isSwimming` covers these cases with a caveat that it triggers when not fully submerged, but it should not be a problem here.